### PR TITLE
Cambios en texto de pagina de inicio e informacion

### DIFF
--- a/module/Transparente/view/transparente/index/about.phtml
+++ b/module/Transparente/view/transparente/index/about.phtml
@@ -11,7 +11,7 @@ Guatemala ocupa el <a href="http://www.transparency.org/cpi2013/results" target=
 En el año 2008 se publica <a href="http://wikiguate.com.gt/wiki/Ley_de_Acceso_a_la_Informaci%C3%B3n_P%C3%BAblica_%28documento%29" target="_blank">Ley de Acceso a la Información Pública</a> que permite el acceso a toda información de la administración pública. A finales del año 2012 se crea <abbr title="Comisión Presidencial de Transparencia">COPRET</abbr>, quién vela por que cada entidad del gobierno publique sus información con el fin de mejorar la transparencia, según el <href="http://www.transparencia.gob.gt/web/images/Acuerdo/acuerdo_360-2012_COPRET.pdf" target="_blank">Acuerdo Gubernativo No. 360-2012</a>. Y hay una oficina <sup>(se requiere más información)</sup> donde se puede hacer solicitudes puntuales de esta información.
 
 </p><p>
-Lamentablemente esta información no es transparente. La información que nos proveen está filtrada, procesada y lo peor de todo, la entregan impresa en papel. Con esa información, no se puede corroborar los datos, no se puede verificar la fuente, no se puede agrupar, sumar, ni filtrar, ni hacer cruce de datos ni procesar más datos que lo que ya está escrito en papel. Lo que permite ver a travez de ello pero que todavía opaca al punto de no permitir ver realmente que hay detrás, no es transparencia, es algo translúcido.
+Lamentablemente esta información no es transparente. La información que nos proveen está filtrada, procesada y lo peor de todo, la entregan impresa en papel. Con esa información, no se puede corroborar los datos, no se puede verificar la fuente, no se puede agrupar, sumar, ni filtrar, ni hacer cruce de datos ni procesar más datos que lo que ya está escrito en papel. Lo que permite ver a través de ello pero que todavía opaca al punto de no permitir ver realmente que hay detrás, no es transparencia, es algo translúcido.
 
 </p><p>
 Aún con la Ley De Acceso a la Información, a los ciudadanos no nos queda más que seguir mintiéndonos a nosotros mismos para creernos que el gobierno está haciendo bien su trabajo.
@@ -20,7 +20,7 @@ Aún con la Ley De Acceso a la Información, a los ciudadanos no nos queda más 
     <img alt="Guatemala Transparente" title="Guatemala Transparente" class="pull-right"
     src="<?=$this->basePath()?>/Transparente/img/logo-home.png" />
 <p>
-El proyecto <abbr title="Guatemala Transparente">GTT</abbr> busca recopilar los datos que por ley ya son públicos, y convertir esos datos translúcidos en datos realmente transparentes, datos que se puedan procesar para servircomo herramienta para una investigación profunda.
+El proyecto <abbr title="Guatemala Transparente">GTT</abbr> busca recopilar los datos que por ley ya son públicos, y convertir esos datos translúcidos en datos realmente transparentes, datos que se puedan procesar para servir como herramienta para una investigación profunda.
 </p>
     <dl>
         <dt>Misión</dt>
@@ -31,10 +31,10 @@ El proyecto <abbr title="Guatemala Transparente">GTT</abbr> busca recopilar los 
     </dl>
 
 <p>
-Un gobierno realmente transparente debe de publicar us datos de forma que no sea necesaria ser re-procesada por un sistema como GTT. La visión es que en un futuro, el gobierno publique por ley la información ordenada en forma digital, para que el trabajo que los voluntarios que creamos GTT hacemos, no sea necesario. Pero mientras ese día llega, GTT recopilará los datos para poder ayudar a hacer visibles las anomalías.
+Un gobierno realmente transparente debe de publicar su información de forma que no sea necesario ser re-procesada por un sistema como GTT. La visión es que en un futuro, el gobierno publique por ley la información ordenada en forma digital, para que el trabajo que los voluntarios que creamos GTT hacemos, no sea necesario. Pero mientras ese día llega, GTT recopilará los datos para poder ayudar a hacer visibles las anomalías.
 </p>
 <p>
-    Todo el código usado para la recopilación de los datos, el portal para re-publicar los datos al públicos, los
+    Todo el código usado para la recopilación de los datos, el portal para re-publicar los datos al público, los
     reportes de inconsistencias e incluso la misma base de datos <a href="https://github.com/str/gtt/" target="_blank">
     son de dominio público</a>, haciendo que cualquier persona pueda ver cómo se obtuvieron los datos o pueda colaborar
     o continuar con el proyecto.
@@ -80,7 +80,7 @@ No hay ninguna ONG, ningún partido político, ningúna organización; somos sim
     ¿Estás interesado en apoyar? Los aportes que podemos recibir son:
 </p>
 <ul>
-    <li>Apoyo técnico: todo el código del proyecto es público y se puede ver, editar y mejorar en el protal en
+    <li>Apoyo técnico: todo el código del proyecto es público y se puede ver, editar y mejorar en el portal de
     github en <a href="https://github.com/str/gtt/" target="_blank">guatemala transparente</a></li>
 
     <li>Tareas específicas: los pendientes por hacer son varios, en especial a estas alturas del proyecto. Llevamos
@@ -88,7 +88,7 @@ No hay ninguna ONG, ningún partido político, ningúna organización; somos sim
     <a href="https://github.com/str/gtt/issues?state=open" target="_blank">manejador de incidencias</a></li>
 
     <li>Donaciones económicas: a pesar que el proyecto está creado por voluntariado que aporta su tiempo libre para la
-    investigación y creación de este, se tienen gastos para contratar el servicio de alojamiento, combra del dominio y
+    investigación y creación de este, se tienen gastos para contratar el servicio de alojamiento, compra del dominio y
     demás que están pendientes. Cualquier donación es bienvenida.
         <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">

--- a/module/Transparente/view/transparente/index/index.phtml
+++ b/module/Transparente/view/transparente/index/index.phtml
@@ -85,7 +85,7 @@
             </div>
             <div class="panel-body">
                 <p>
-                    Guatecompras Transparente es un proyecto colaborativo donde, con el tema de transparencia siempre
+                    Guatemala Transparente es un proyecto colaborativo donde, con el tema de transparencia siempre
                     primero, el código fuente es libre para que cualquiera lo pueda ver, mejorar, y replicar.
                 </p>
                 <p>

--- a/module/Transparente/view/transparente/proveedores/no-fiscal.phtml
+++ b/module/Transparente/view/transparente/proveedores/no-fiscal.phtml
@@ -22,7 +22,7 @@ $pager = $this->paginationControl(
 <p>
     Del catálogo de proveedores recopilados, este es el listado de los proveedores que no tienen dirección fiscal
     publicada. De los  <span class="badge">3,363</span> proveedores en Guatecompras, más del <span class="badge">60%</span>
-    de proveedores no tienen su dirección fiscal publicada en por el portal de Guatecomrpas.  Ponemos a la par si
+    de proveedores no tienen su dirección fiscal publicada en por el portal de Guatecompras.  Ponemos a la par si
     detectamos o no la dirección comercial como comparativa.
 </p>
 <table class="table">

--- a/module/Transparente/view/transparente/representante-legal/index.phtml
+++ b/module/Transparente/view/transparente/representante-legal/index.phtml
@@ -20,7 +20,7 @@ $pager = $this->paginationControl(
 ?>
 <h1>Representantes legales</h1>
 <p>
-    Catálogo de representantes legales recopilados al importar los proveedores. .
+    Catálogo de representantes legales recopilados al importar los proveedores.
 </p>
 <table class="table">
     <thead>

--- a/module/Transparente/view/transparente/representante-legal/multi-proveedor.phtml
+++ b/module/Transparente/view/transparente/representante-legal/multi-proveedor.phtml
@@ -32,11 +32,11 @@ $pager = $this->paginationControl(
 </p>
 <p>
     También puede significar que existe algún favoritismo para que sean las empresas de la misma persona las que ganen
-    los concuros.
+    los concursos.
 </p>
 <p>
     Puede significar también que para llenar requisitos (mínimo 3 ofertas de diferentes proveedores, por ejemplo),
-    hagan las ofertas con diferentes empresas del mismo representante legal. No importa que empresa seaa la ganadora,
+    hagan las ofertas con diferentes empresas del mismo representante legal. No importa que empresa sea la ganadora,
     el dueño es el mismo.
 </p>
 <table class="table">


### PR DESCRIPTION
Index: Se cambio el nombre en la pagina de inicio de "Guatecompras transparente" a "Guatemala transparente" por consistencia.
Info: Algunas palabras estan mal escritas, se hicieron cambios en las palabras.
Se examinaron las demas vistas y se cambio acorde a lo que se considero correcto.
